### PR TITLE
Added filtering for dereferenced nodes

### DIFF
--- a/lib/dereference.js
+++ b/lib/dereference.js
@@ -39,6 +39,9 @@ function crawl (obj, path, pathFromRoot, parents, $refs, options) {
     circular: false
   };
 
+  const isApplicable = typeof options.dereference.filter === "function"
+    ? options.dereference.filter : () => true;
+
   if (obj && typeof obj === "object") {
     parents.push(obj);
 
@@ -53,21 +56,23 @@ function crawl (obj, path, pathFromRoot, parents, $refs, options) {
         let keyPathFromRoot = Pointer.join(pathFromRoot, key);
         let value = obj[key];
         let circular = false;
+        dereferenced = false;
 
         if ($Ref.isAllowed$Ref(value, options)) {
           dereferenced = dereference$Ref(value, keyPath, keyPathFromRoot, parents, $refs, options);
-          circular = dereferenced.circular;
-          obj[key] = dereferenced.value;
         }
         else {
           if (parents.indexOf(value) === -1) {
             dereferenced = crawl(value, keyPath, keyPathFromRoot, parents, $refs, options);
-            circular = dereferenced.circular;
-            obj[key] = dereferenced.value;
           }
           else {
             circular = foundCircularReference(keyPath, $refs, options);
           }
+        }
+
+        if (dereferenced !== false && (!dereferenced.value || isApplicable(dereferenced.value))) {
+          circular = dereferenced.circular;
+          obj[key] = dereferenced.value;
         }
 
         // Set the "isCircular" flag if this or any other property is circular


### PR DESCRIPTION
Related https://github.com/Smartum/smartum-core/pull/2537

Ability to filter which schema can be dereferenced by checking its contents.

**Usage**

```
    const refParser = require("json-schema-ref-parser");

    refParser.dereference(originalJsonSchemaObj, {
        // dereference the following schemas: model properties, path & query parameters
        dereference: {
            filter: (value) => {
                return ['query', 'path'].includes(value.in)
                    || ['string', 'array', 'integer', 'number', 'boolean'].includes(value.type);
            }
        }
    }).then((schemaDerefed) => {
        // ...
    });
```

**Effect**

Before:

```
      "AccountDepositPaytrailInitRequest": {
        "type": "object",
        "properties": {
          "amount": {
            "$ref": "#/components/schemas/Record/properties/amount"
          },
          "itemName": {
            "$ref": "#/components/schemas/ItemSearchResult/properties/name"
          },
          "userId": {
            "$ref": "#/components/schemas/UserRearchResult/properties/id"
          }
        },
        "required": [
          "amount",
          "itemName"
        ]
      },
```

After:

```
      "AccountDepositPaytrailInitRequest": {
        "type": "object",
        "properties": {
          "amount": {
            "type": "integer",
            "description": "Money amount.",
            "example": 17500
          },
          "itemName": {
            "type": "string",
            "description": "Technical name of the product (item).",
            "minLength": 1,
            "maxLength": 128,
            "example": "EXERCISE_EMONEY"
          },
          "userId": {
            "type": "integer",
            "description": "User identifier.",
            "readOnly": true,
            "minimum": 1,
            "example": 1
          }
        },
        "required": [
          "amount",
          "itemName"
        ]
      }
```